### PR TITLE
Reduce # of objects saved in XQ cache

### DIFF
--- a/event-processor/eventhandler.py
+++ b/event-processor/eventhandler.py
@@ -455,15 +455,15 @@ def start_process(zmq_queue, event_queue, CHAIN_HOST, event_type):
 				self.events_cache.insert(0, value)
 
 		def remove_key(self, key):
-			if key == 'token_data_cache' and len(self.token_data_cache.keys())>=2000:
+			if key == 'token_data_cache' and len(self.token_data_cache.keys())>=500:
 				self.token_data_cache.pop(random.choice(self.token_data_cache.keys()))
-			elif key == 'coin_data_cache' and len(self.coin_data_cache.keys())>=2000:
+			elif key == 'coin_data_cache' and len(self.coin_data_cache.keys())>=500:
 				self.coin_data_cache.pop(random.choice(self.coin_data_cache.keys()))
-			elif key == 'functions_cache' and len(self.functions_cache.keys())>=2000:
+			elif key == 'functions_cache' and len(self.functions_cache.keys())>=500:
 				self.functions_cache.pop(random.choice(self.functions_cache.keys()))
-			elif key == 'contracts_cache' and len(self.contracts_cache.keys())>=2000:
+			elif key == 'contracts_cache' and len(self.contracts_cache.keys())>=500:
 				self.contracts_cache.pop(random.choice(self.contracts_cache.keys()))
-			elif key == 'events_cache' and len(self.events_cache)>=2000:
+			elif key == 'events_cache' and len(self.events_cache)>=500:
 				self.events_cache.pop()
 
 	adapter = requests.adapters.HTTPAdapter(pool_connections=30, pool_maxsize=30)


### PR DESCRIPTION
This commit reduces the objects in cache to 500 for testing. Further reduction to 100 can be made if 500 isn't low enough.