### PR TITLE
re-implement index from inception block

### DIFF
--- a/event-processor/eventhandler.py
+++ b/event-processor/eventhandler.py
@@ -34,7 +34,8 @@ def start_process(zmq_queue, event_queue, CHAIN_HOST, event_type):
 			self.event_type = self.get_event_topic()
 			self.get_latest_block()
 			self.start_block = self.load_start_block()
-			self.current_block = self.latest_block if self.global_vars.return_key('backblock_progress') == None else self.global_vars.return_key('backblock_progress')
+			#self.current_block = self.latest_block if self.global_vars.return_key('backblock_progress') == None else self.global_vars.return_key('backblock_progress')
+			self.current_block = self.start_block if self.global_vars.return_key('backblock_progress') == None else self.global_vars.return_key('backblock_progress')
 			self.current_block_forward = self.latest_block if self.global_vars.return_key('forwardblock_progress') == None else self.global_vars.return_key('forwardblock_progress')
 			self.lock_forward = False
 			self.lock_backward = False
@@ -280,18 +281,22 @@ def start_process(zmq_queue, event_queue, CHAIN_HOST, event_type):
 				if not self.lock_backward:
 					try:
 						if self.start_block != 'None':
-							if self.current_block>self.start_block:
+							#if self.current_block>self.start_block:
+							if self.current_block<self.latest_block:
 								self.logger.info(f'{thread} {self.chain_name} {self.current_block} BACKWARD')
 								backward_filter = self.web2.eth.filter({
-										'fromBlock': hex(int(self.current_block)-1),
-										'toBlock': hex(int(self.current_block)),
+										#'fromBlock': hex(int(self.current_block)-1),
+										#'toBlock': hex(int(self.current_block)),
+										'fromBlock': hex(int(self.current_block)),
+ 										'toBlock': hex(int(self.current_block)+1)
 										'topics': [self.event_type]
 									})
 								for event in backward_filter.get_all_entries():
 									self.event_queue.put(event)
 								self.web2.eth.uninstall_filter(backward_filter.filter_id)
 								self.lock_backward = True
-								self.current_block = self.current_block - 1 if self.current_block > self.start_block else self.start_block
+								#self.current_block = self.current_block - 1 if self.current_block > self.start_block else self.start_block
+								self.current_block = self.current_block + 1 if self.current_block < self.latest_block else self.latest_block
 								self.global_vars.update_key('backblock_progress', self.current_block)
 								self.lock_backward = False
 						else:


### PR DESCRIPTION
reverting the revert!
I'm assuming `fix_revert_timestamp` is the branch naoki/murano is using to implement redis caching of timestamp data. If so, this change will be needed for redis caching to work.