### PR TITLE
Reverted openresty/openresty:alpine-fat to earlier version

### DIFF
--- a/reverse-proxy/Dockerfile
+++ b/reverse-proxy/Dockerfile
@@ -1,5 +1,6 @@
 #FROM nginx:1.15-alpine
-FROM openresty/openresty:alpine-fat
+#FROM openresty/openresty:alpine-fat
+FROM openresty/openresty:1.19.9.1-12-alpine-fat
 RUN mkdir -p /run/nginx
 RUN apk add --no-cache nginx-mod-http-lua coreutils
 RUN apk add python3 python3-dev py3-pip


### PR DESCRIPTION
The `exrproxy-env_xquery-reverse-proxy` image is built based on the `openresty/openresty:alpine-fat` image. Around 25 May, 2022, a new version of `openresty/openresty:alpine-fat` was pushed to docker hub which somehow broke the `exrproxy-env_xquery-reverse-proxy` image, causing the *xquery-reverse-proxy* container to continuously restart itself while printing errors to the logs like this:
```
nginx: [alert] failed to load the 'resty.core' module (https://github.com/openresty/lua-resty-core); ensure you are using an OpenResty release from https://openresty.org/en/download.html (reason: /usr/local/openresty/lualib/resty/core/base.lua:24: ngx_http_lua_module 0.10.21 required) in /etc/nginx/nginx.conf:43
```

There may be a better way to fix this issue, but this PR fixes it for now simply by forcing the `exrproxy-env_xquery-reverse-proxy` image to be built from the *openresty:alpine-fat* image that was released around 1 May, 2022, 3 weeks prior to the release that broke things. Note, this fix has been tested and it does indeed fix the issue.