### PR TITLE
disable scalene

### DIFF
--- a/event-processor/Dockerfile
+++ b/event-processor/Dockerfile
@@ -12,4 +12,8 @@ RUN apt-get install -y build-essential musl-dev gcc g++ libffi-dev libssl-dev py
     && rm -rf /usr/share/man \
     && rm -rf /tmp/*
 
-CMD sleep 20 && python3 /app/manager/index_topics.py && python3 -m scalene --profile-interval 10.0 --cli --html --outfile /app/manager/profile/$NAME.html /app/manager/main.py
+#Scalene Profiler
+#CMD sleep 20 && python3 /app/manager/index_topics.py && python3 -m scalene --profile-interval 10.0 --cli --html --outfile /app/manager/profile/$NAME.html /app/manager/main.py
+
+CMD sleep 20 && python3 /app/manager/index_topics.py && python3 /app/manager/main.py
+


### PR DESCRIPTION
This PR just re-applies the commit to disable scalene in the Dockerfile, a commit which was lost when we reverted `master` branch back to be equal to `xq_pre_mp_cache2` branch.
Scalene is slowing down event processing and giving errors in logs like:
```
  File "/usr/local/lib/python3.9/site-packages/scalene/scalene_statistics.py", line 354, in merge_stats
    value = unpickler.load()
_pickle.UnpicklingError: pickle data was truncated
```