### PR TITLE
Nevm sync detection

### DIFF
--- a/event-processor/eventhandler.py
+++ b/event-processor/eventhandler.py
@@ -238,6 +238,7 @@ class EventHandler:
 	#listen loop for incoming events | backward listner
 	def forward_loop(self, thread):
 		self.logger.info(f'{thread} Starting forward listener...')
+		SLEEP_TIME_BEFORE_INDEXING_NEXT_BLOCK = 0.01  # This variable is used to reduce CPU load after old blocks are indexed
 		
 		while self.running and self.errors < 2:
 			if not self.lock_forward:
@@ -251,11 +252,13 @@ class EventHandler:
 						self.event_queue.put(event)
 					self.web2.eth.uninstall_filter(forward_filter.filter_id)
 					self.lock_forward = True
-					self.get_latest_block()
+					if self.current_block_forward >= self.latest_block: # This if condition will allow faster indexing of old blocks
+						self.get_latest_block() # No need to call this slow web3 method while backfill indexing old blocks
+						SLEEP_TIME_BEFORE_INDEXING_NEXT_BLOCK = 0.5 if self.current_block_forward >= self.latest_block else 0.01
 					self.current_block_forward = self.current_block_forward + 1 if self.current_block_forward < self.latest_block else self.latest_block
 					self.global_vars.update_key('forwardblock_progress', self.current_block_forward)
 					self.lock_forward = False
-					time.sleep(0.01)
+					time.sleep(SLEEP_TIME_BEFORE_INDEXING_NEXT_BLOCK)
 				except ValueError as e:
 					self.logger.critical('ValueError in Listener loop!',exc_info=True)
 				except Exception as e:
@@ -265,39 +268,39 @@ class EventHandler:
 						self.running = False
 						self.global_vars.update_key('running', False)
 
-	def back_loop(self, thread):
-		self.logger.info(f'{thread} Starting back listener...')
-		while self.back_running and self.errors < 2:
-			if not self.lock_backward:
-				try:
-					if self.start_block != 'None':
-						#if self.current_block>self.start_block:
-						if self.current_block<self.latest_block:
-							self.logger.info(f'{thread} {self.chain_name} {self.current_block} BACKWARD')
-							backward_filter = self.web2.eth.filter({
-									#'fromBlock': hex(int(self.current_block)-1),
-									#'toBlock': hex(int(self.current_block))
-									'fromBlock': hex(int(self.current_block)),
-									'toBlock': hex(int(self.current_block)+1)
-								})
-							for event in backward_filter.get_all_entries():
-								self.event_queue.put(event)
-							self.web2.eth.uninstall_filter(backward_filter.filter_id)
-							self.lock_backward = True
-							#self.current_block = self.current_block - 1 if self.current_block > self.start_block else self.start_block
-							self.current_block = self.current_block + 1 if self.current_block < self.latest_block else self.latest_block
-							self.global_vars.update_key('backblock_progress', self.current_block)
-							self.lock_backward = False
-					else:
-						self.back_running = False
-					time.sleep(0.01)
-				except ValueError as e:
-					self.logger.critical('ValueError in Back Listener loop!',exc_info=True)
-				except Exception as e:
-					self.logger.critical('Exception in Back Listener loop!',exc_info=True)
-					self.errors += 0.2
-					if self.errors > 2:
-						self.back_running = False
+#	def back_loop(self, thread):
+#		self.logger.info(f'{thread} Starting back listener...')
+#		while self.back_running and self.errors < 2:
+#			if not self.lock_backward:
+#				try:
+#					if self.start_block != 'None':
+#						#if self.current_block>self.start_block:
+#						if self.current_block<self.latest_block:
+#							self.logger.info(f'{thread} {self.chain_name} {self.current_block} BACKWARD')
+#							backward_filter = self.web2.eth.filter({
+#									#'fromBlock': hex(int(self.current_block)-1),
+#									#'toBlock': hex(int(self.current_block))
+#									'fromBlock': hex(int(self.current_block)),
+#									'toBlock': hex(int(self.current_block)+1)
+#								})
+#							for event in backward_filter.get_all_entries():
+#								self.event_queue.put(event)
+#							self.web2.eth.uninstall_filter(backward_filter.filter_id)
+#							self.lock_backward = True
+#							#self.current_block = self.current_block - 1 if self.current_block > self.start_block else self.start_block
+#							self.current_block = self.current_block + 1 if self.current_block < self.latest_block else self.latest_block
+#							self.global_vars.update_key('backblock_progress', self.current_block)
+#							self.lock_backward = False
+#					else:
+#						self.back_running = False
+#					time.sleep(0.01)
+#				except ValueError as e:
+#					self.logger.critical('ValueError in Back Listener loop!',exc_info=True)
+#				except Exception as e:
+#					self.logger.critical('Exception in Back Listener loop!',exc_info=True)
+#					self.errors += 0.2
+#					if self.errors > 2:
+#						self.back_running = False
 
 	def queue_handler(self, thread):
 		self.logger.info('Starting Worker: {}'.format(thread))

--- a/event-processor/main.py
+++ b/event-processor/main.py
@@ -110,8 +110,8 @@ def main():
 				live = eth_live(CHAIN_HOST)
 			elif 'AVAX' in CHAIN_NAME:
 				live = avax_live(CHAIN_HOST)
-			elif 'SYS' in CHAIN_NAME:
-				live = eth_live(CHAIN_HOST)
+			elif 'NEVM' in CHAIN_NAME:
+				live = nevm_live(CHAIN_HOST)
 			if live == False:
 				logger.info(f'{CHAIN_NAME} node syncing... Retrying in 30 seconds')
 				time.sleep(30)
@@ -129,6 +129,7 @@ def main():
 					for i in range(0, cpus-1):
 						if i in [0]:
 							futures.append(executor.submit(start_process, zmq_queue, event_queue, CHAIN_HOST, 'forward', gv))
+                                                # not using backward processing atm...
 #						elif i in [1]:
 #							futures.append(executor.submit(start_process, zmq_queue, backevent_queue, CHAIN_HOST, 'backward', gv))	
 #						wtf was the purpose of the following elif??? Seems like a no-op to me, given the following else clause

--- a/event-processor/utils/liveness.py
+++ b/event-processor/utils/liveness.py
@@ -25,3 +25,18 @@ def avax_live(HOST):
 			return False
 	except Exception as e:
 		return False
+
+def nevm_live(HOST):
+	try:
+		payload = {'jsonrpc': '2.0', 'method': 'eth_blockNumber', 'params': [], 'id': 1}
+		headers = {'Content-Type':'application/json'}
+		resp = requests.post(HOST,headers=headers,json=payload)
+		data = resp.json()
+		if data['result'] < hex(107659):  # 107659 is the NEVM block number now. (Little hack)
+			return False
+		else:
+			return True
+	except Exception as e:
+		return False
+
+


### PR DESCRIPTION
This fixes the event-processor container so it no longer starts trying to process blocks from the Syscoin NEVM chain until the chain is fully synced. The original implementation assumed the `eth_syncing` method of the NEVM chain works like the `eth_syncing` method on the ETH chain. This is *not* the case as the `eth_syncing` method of the NEVM chain **always** returns `False`.

A few minor performance related improvements are also included in this PR. For example, a slow web3 call to get the latest block available on the chain is eliminated from the inner loop until all backfill indexing has caught up with the latest block of the chain that existed when the backfilling was begun.